### PR TITLE
Add dev banner

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -10,6 +10,14 @@
 
 .image { width: 100%; }
 
+.environment-banner {
+  color: $white;
+  font-family: monospace;
+  font-size: 1.25em;
+  padding: .75em;
+  text-align: center;
+}
+
 // Links
 a { color: $link-color; }
 

--- a/app/helpers/environment_banner_helper.rb
+++ b/app/helpers/environment_banner_helper.rb
@@ -1,0 +1,22 @@
+module EnvironmentBannerHelper
+  def current_branch
+    if git_available?
+      `git rev-parse --abbrev-ref HEAD`.chomp
+    else
+      ENV.fetch("CURRENT_BRANCH", "--branch-not-found--")
+    end
+  end
+
+  def current_sha
+    if git_available?
+      `git log --oneline -1`
+    else
+      ENV.fetch("CURRENT_SHA", "--sha-not-found--")
+    end
+  end
+
+  def git_available?
+    to_dev_null = "> /dev/null 2>&1"
+    system("which git #{to_dev_null} && git rev-parse --git-dir #{to_dev_null}")
+  end
+end

--- a/app/views/layouts/_environment_banner.html.erb
+++ b/app/views/layouts/_environment_banner.html.erb
@@ -1,0 +1,5 @@
+<% unless Rails.env.production? %>
+  <div class='environment-banner bg-secondary'>
+    👍 <%= Rails.env.upcase %>: <%= "#{current_branch}" %> 👍
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
   </head>
 
   <body>
+    <%= render 'layouts/environment_banner' %>
     <%= render 'shared/navbar/main' %>
     <div class='container'>
       <%= render 'shared/flashes' %>


### PR DESCRIPTION
## Problems Solved
> Too many times, I have found myself refreshing the production page and wondering why my changes weren't showing up. This is frustrating and a silly waste of time. Now it is clear when I am looking at a page in my development environment.

## Screenshots
<img width="718" alt="Screenshot 2020-01-04 10 33 26" src="https://user-images.githubusercontent.com/8680712/71768681-f7e74380-2edd-11ea-9ce1-3118ececff8a.png">


## Things Learned
> It is nice to be able to reference a PR from another project that has all of the files you need to do a specific thing and no more. It is a nice win of doing small and focused PRs.
