### PR TITLE
Enable markdown with coderay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       # Run linters!
       # - run: bundle exec rubocop
       # - run: bundle exec reek
-      - run: bundle exec scss-lint app/assets/stylesheets/**.scss
+      - run: bundle exec scss-lint app/assets/stylesheets/**.scss --exclude app/assets/stylesheets/coderay.scss
 
       # Run tests!
       - run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.3'
 
 gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb
-gem 'coderay'                   # syntax highlighting
+gem 'coderay'                   # syntax highlighting: http://coderay.rubychan.de/
 gem 'coffee-rails'              # Use CoffeeScript for .coffee assets and views
 gem 'devise'                    # User authentication
 gem 'jbuilder', '~> 2.5'        # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.3'
 
 gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb
+gem 'coderay'                   # syntax highlighting
 gem 'coffee-rails'              # Use CoffeeScript for .coffee assets and views
 gem 'devise'                    # User authentication
 gem 'jbuilder', '~> 2.5'        # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
@@ -15,6 +16,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.3'            # Use Puma as the app server
 gem 'rack', '>= 2.0.6'          # Upgrade for security update
 gem 'rails', '~> 6.0.1'         # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'redcarpet', github: 'vmg/redcarpet' # markdown
 gem 'sass-rails', '~> 6.0'      # Use SCSS for stylesheets
 gem 'uglifier', '>= 1.3.0'      # Use Uglifier as compressor for JavaScript assets
 gem 'will_paginate', '~> 3.2.0' # pagination. Styles: http://mislav.github.io/will_paginate/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GIT
   specs:
     rspec-support (3.9.0.pre)
 
+GIT
+  remote: https://github.com/vmg/redcarpet.git
+  revision: 6270d6b4ab6b46ee6bb57a6c0e4b2377c01780ae
+  specs:
+    redcarpet (3.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -421,6 +427,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bullet
   byebug
+  coderay
   coffee-rails
   devise
   factory_bot_rails
@@ -436,6 +443,7 @@ DEPENDENCIES
   rack (>= 2.0.6)
   rails (~> 6.0.1)
   rails-erd
+  redcarpet!
   reek
   rspec-core!
   rspec-expectations!

--- a/app/assets/stylesheets/coderay.scss
+++ b/app/assets/stylesheets/coderay.scss
@@ -1,0 +1,148 @@
+@import 'variables';
+
+code {
+  color: #000;
+  background-color: $inline-code;
+  padding: 2px 5px;
+  border-radius: 2px;
+}
+
+.CodeRay {
+  /* background-color: #FFF; */
+  /* border: 1px solid #CCC; */
+  font-family: Monaco, "Courier New", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
+  color: #000;
+  padding: 1em 0px 1em 1em;
+  margin: 1em 0px;
+}
+
+.CodeRay pre {
+  margin: 0px;
+}
+
+div.CodeRay { }
+span.CodeRay { white-space: pre; border: 0px; padding: 2px }
+
+table.CodeRay {
+  border-collapse: collapse;
+  width: 100%;
+  padding: 2px;
+  background-color: $code-block;
+}
+table.CodeRay td {
+  padding: 1em 0.5em;
+  vertical-align: top;
+}
+
+.CodeRay .line-numbers, .CodeRay .no {
+  background-color: $code-block;
+  color: #AAA;
+  text-align: right;
+  padding-right: 15px;
+}
+
+.CodeRay .line-numbers a {
+  color: #AAA;
+}
+
+.CodeRay .line-numbers tt { font-weight: bold }
+.CodeRay .line-numbers .highlighted { color: red }
+.CodeRay .line { display: block; float: left; width: 100%; }
+.CodeRay span.line-numbers { padding: 0px 4px }
+.CodeRay .code { width: 100% }
+
+ol.CodeRay { font-size: 10pt }
+ol.CodeRay li { white-space: pre }
+
+.CodeRay .code pre { overflow: auto }
+.CodeRay .debug { color:white ! important; background:blue ! important; }
+
+.CodeRay .annotation { color:#007 }
+.CodeRay .attribute-name { color:#f08 }
+.CodeRay .attribute-value { color:#700 }
+.CodeRay .binary { color:#509; font-weight:bold }
+.CodeRay .comment  { color:#998; font-style: italic;}
+.CodeRay .char { color:#04D }
+.CodeRay .char .content { color:#04D }
+.CodeRay .char .delimiter { color:#039 }
+.CodeRay .class { color:#458; font-weight:bold }
+.CodeRay .complex { color:#A08; font-weight:bold }
+.CodeRay .constant { color:teal; }
+.CodeRay .color { color:#0A0 }
+.CodeRay .class-variable { color:#369 }
+.CodeRay .decorator { color:#B0B; }
+.CodeRay .definition { color:#099; font-weight:bold }
+.CodeRay .directive { color:#088; font-weight:bold }
+.CodeRay .delimiter { color:black }
+.CodeRay .doc { color:#970 }
+.CodeRay .doctype { color:#34b }
+.CodeRay .doc-string { color:#D42; font-weight:bold }
+.CodeRay .escape  { color:#666; font-weight:bold }
+.CodeRay .entity { color:#800; font-weight:bold }
+.CodeRay .error { color:#F00; }
+.CodeRay .exception { color:#C00; font-weight:bold }
+.CodeRay .filename { color:#099; }
+.CodeRay .function { color:#900; font-weight:bold }
+.CodeRay .global-variable { color:teal; font-weight:bold }
+.CodeRay .hex { color:#058; font-weight:bold }
+.CodeRay .integer  { color:#099; }
+.CodeRay .include { color:#B44; font-weight:bold }
+.CodeRay .inline { color: black }
+.CodeRay .inline .inline { background: #ccc }
+.CodeRay .inline .inline .inline { background: #bbb }
+.CodeRay .inline .inline-delimiter { color: #D14; }
+.CodeRay .inline-delimiter { color: #D14; }
+.CodeRay .important { color:#f00; }
+.CodeRay .interpreted { color:#B2B; font-weight:bold }
+.CodeRay .instance-variable { color:teal }
+.CodeRay .label { color:#970; font-weight:bold }
+.CodeRay .local-variable { color:#963 }
+.CodeRay .octal { color:#40E; font-weight:bold }
+.CodeRay .operator { }
+.CodeRay .predefined-constant {  font-weight:bold }
+.CodeRay .predefined { color:#369; font-weight:bold }
+.CodeRay .preprocessor { color:#579; }
+.CodeRay .pseudo-class { color:#00C; font-weight:bold }
+.CodeRay .predefined-type { color:#074; font-weight:bold }
+.CodeRay .reserved, .keyword  { color:#000; font-weight:bold }
+
+.CodeRay .key { color: #808; }
+.CodeRay .key .delimiter { color: #606; }
+.CodeRay .key .char { color: #80f; }
+.CodeRay .value { color: #088; }
+
+.CodeRay .regexp { background-color:#fff0ff }
+.CodeRay .regexp .content { color:#808 }
+.CodeRay .regexp .delimiter { color:#404 }
+.CodeRay .regexp .modifier { color:#C2C }
+.CodeRay .regexp .function  { color:#404; font-weight: bold }
+
+.CodeRay .string { color: #D20; }
+.CodeRay .string .string { }
+.CodeRay .string .string .string { background-color:#ffd0d0 }
+.CodeRay .string .content { color: #D14; }
+.CodeRay .string .char { color: #D14; }
+.CodeRay .string .delimiter { color: #D14; }
+
+.CodeRay .shell { color:#D14 }
+.CodeRay .shell .content { }
+.CodeRay .shell .delimiter { color:#D14 }
+
+.CodeRay .symbol { color:#990073 }
+.CodeRay .symbol .content { color:#A60 }
+.CodeRay .symbol .delimiter { color:#630 }
+
+.CodeRay .tag { color:#070 }
+.CodeRay .tag-special { color:#D70; font-weight:bold }
+.CodeRay .type { color:#339; font-weight:bold }
+.CodeRay .variable  { color:#036 }
+
+.CodeRay .insert { background: #afa; }
+.CodeRay .delete { background: #faa; }
+.CodeRay .change { color: #aaf; background: #007; }
+.CodeRay .head { color: #f8f; background: #505 }
+
+.CodeRay .insert .insert { color: #080; font-weight:bold }
+.CodeRay .delete .delete { color: #800; font-weight:bold }
+.CodeRay .change .change { color: #66f; }
+.CodeRay .head .head { color: #f4f; }

--- a/app/assets/stylesheets/coderay.scss
+++ b/app/assets/stylesheets/coderay.scss
@@ -79,7 +79,7 @@ ol.CodeRay li { white-space: pre }
 .CodeRay .doc-string { color:#D42; font-weight:bold }
 .CodeRay .escape  { color:#666; font-weight:bold }
 .CodeRay .entity { color:#800; font-weight:bold }
-.CodeRay .error { color:#F00; }
+.CodeRay .error { color:#F00 }
 .CodeRay .exception { color:#C00; font-weight:bold }
 .CodeRay .filename { color:#099; }
 .CodeRay .function { color:#900; font-weight:bold }

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -71,3 +71,11 @@ a { color: $link-color; }
   font-size: .4em;
   padding: 1px 4px;
 }
+
+// markdown
+code {
+  color: $inline-code;
+  background-color: lighten($inline-code, 35%);
+  padding: 2px 5px;
+  border-radius: 5px;
+}

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -71,16 +71,3 @@ a { color: $link-color; }
   font-size: .4em;
   padding: 1px 4px;
 }
-
-// markdown
-code {
-  color: $inline-code;
-  background-color: lighten($inline-code, 35%);
-  padding: 2px 5px;
-  border-radius: 5px;
-}
-
-pre {
-  padding: 10px 15px;
-  background-color: lighten($light-gray, 2%);
-}

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -79,3 +79,8 @@ code {
   padding: 2px 5px;
   border-radius: 5px;
 }
+
+pre {
+  padding: 10px 15px;
+  background-color: lighten($light-gray, 2%);
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -23,7 +23,7 @@ $link-color: $brand-light-blue;
 
 // Syntax Highlighting
 $jekyll: #eef;
-$coderay: #ECECEC;
+$coderay: #ececec;
 $github: #f6f8fa;
 $inline-code: $github;
 $code-block: $github;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -20,4 +20,10 @@ $gray: #808080;
 $medium-gray: #ccc;
 $link-color: $brand-light-blue;
 // $error: ff0000;
-$inline-code: #e83e8c;
+
+// Syntax Highlighting
+$jekyll: #eef;
+$coderay: #ECECEC;
+$github: #f6f8fa;
+$inline-code: $github;
+$code-block: $github;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -20,3 +20,4 @@ $gray: #808080;
 $medium-gray: #ccc;
 $link-color: $brand-light-blue;
 // $error: ff0000;
+$inline-code: #e83e8c;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
 
   class CodeRayify < Redcarpet::Render::HTML
     def block_code(code, language)
-     CodeRay.scan(code, language).div
+     CodeRay.scan(code, language).div(line_numbers: :table)
     end
   end
 
@@ -52,7 +52,7 @@ module ApplicationHelper
       with_toc_data: true,
       prettify: true
     }
-    
+
     redcarpet_options = {
       autolink: true,
       disable_indented_code_blocks: false,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'coderay'
 
 module ApplicationHelper
   def page_title
@@ -35,5 +36,38 @@ module ApplicationHelper
 
   def button_class(style = 'primary')
     "btn btn-sm btn-outline-#{style}"
+  end
+
+  class CodeRayify < Redcarpet::Render::HTML
+    def block_code(code, language)
+     CodeRay.scan(code, language).div
+    end
+  end
+
+  def markdown(text)
+    coderay_options = {
+      filter_html: true,
+      hard_wrap: true,
+      safe_links_only: true,
+      with_toc_data: true,
+      prettify: true
+    }
+    
+    redcarpet_options = {
+      autolink: true,
+      disable_indented_code_blocks: false,
+      fenced_code_blocks: true,
+      highlight: true,
+      lax_html_blocks: true,
+      lax_spacing: true,
+      no_intra_emphasis: true,
+      strikethrough: true,
+      superscript: true,
+      tables: true,
+    }
+
+    coderayified = CodeRayify.new(coderay_options)
+    markdown_to_html = Redcarpet::Markdown.new(coderayified, redcarpet_options)
+    markdown_to_html.render(text).html_safe
   end
 end

--- a/app/views/accomplishments/_accomplishment.html.erb
+++ b/app/views/accomplishments/_accomplishment.html.erb
@@ -11,7 +11,7 @@
     <% if accomplishment.given_by.present? %>
       <h5 class="card-title"><%= accomplishment.given_by %> said:</h5>
     <% end %>
-    <%= simple_format(accomplishment.description, { class: 'card-text' }, wrapper_tag: 'p') %>
+    <%= markdown(accomplishment.description) %>
     <small class="text-muted">
       <%= display_categories(accomplishment) %>
       <%= link_to 'edit', edit_accomplishment_path(accomplishment), class: 'float-right ml-2' %>


### PR DESCRIPTION
## Related Issues & PRs
Closes #17

## Problems Solved
> I have some markdown, including `pre` and `code` tags in some of my TILs. There were no styles associated with these tags, so it made the posts hard to read. Now the the body accepts markdown and renders it with syntax highlighting.  

## Screenshots
Before
<img width="497" alt="Screenshot 2020-02-22 10 20 22" src="https://user-images.githubusercontent.com/8680712/75095672-01477080-555d-11ea-8e10-396482ec1576.png">

After
<img width="628" alt="Screenshot 2020-02-22 10 20 00" src="https://user-images.githubusercontent.com/8680712/75095671-00164380-555d-11ea-847f-f7713e09156d.png">


## Things Learned
> This work required 2 steps: 1) getting a markdown parser (redcarpet or kramdown) and 2) getting syntax highlighting (coderay or pygments). The markdown part is pretty simple though not easy because the documentation is lacking. The syntax highlighting _feels_ like it should be simple, but none of it is rendering properly. I'm not in love with the syntax highlighting that I'm deploying. But it is an improvement, so I think it is deploy-worthy.
