### PR TITLE
Adjust accomplishment card links for easier usage

### DIFF
--- a/app/views/accomplishments/_accomplishment.html.erb
+++ b/app/views/accomplishments/_accomplishment.html.erb
@@ -1,10 +1,10 @@
 <div class="card mb-3 <%= accomplishment.accomplishment_type.name.downcase %>-card">
   <div class="card-header">
-    <%= accomplishment.date %>
+    <%= accomplishment.accomplishment_type_name %> <%= accomplishment.date %>
     <% if accomplishment.bookmarked? %>
       <i class="fas fa-bookmark float-right ml-2"></i>
     <% end %>
-    <span class="float-right ml-2"><%= accomplishment.accomplishment_type_name %></span>
+    <span class="float-right ml-2"><%= link_to 'edit', edit_accomplishment_path(accomplishment), class: button_class('btn btn-sm btn-light float-right ml-2') %></span>
   </div>
   <div class="card-body">
     <%= image_tag(accomplishment.image_url, class: 'image', title: accomplishment.date) if accomplishment.image_url.present? %>
@@ -14,7 +14,7 @@
     <%= markdown(accomplishment.description) %>
     <small class="text-muted">
       <%= display_categories(accomplishment) %>
-      <%= link_to 'edit', edit_accomplishment_path(accomplishment), class: 'float-right ml-2' %>
+
       <%= link_to 'related info', accomplishment.url, target: '_blank', class: 'float-right ml-2' if accomplishment.url.present? %>
     </small>
   </div>


### PR DESCRIPTION
## Problems Solved
As i've used this app, i've found that i'd prefer for some information to appear in different places. This PR moves info:
* accomplishment type over to left next to date
* link to edit up into banner
