### PR TITLE
Make search form mobile-friendly

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
 ## Related Issues & PRs
-> Closes #X
+Closes #X
 
 ## Problems Solved
->
+*
 
 ## Screenshots
 [screenshots here]
 
 ## Things Learned
->
+*

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -14,7 +14,7 @@
 
   <div class="field">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
     <% if @minimum_password_length %>
       <br />
       <em><%= @minimum_password_length %> characters minimum</em>
@@ -23,16 +23,16 @@
 
   <div class="field">
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
   </div>
 
   <div class="field">
     <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
+    <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "Update", class: 'btn btn-primary' %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
   </div>
 
   <div class="field">
@@ -13,16 +13,16 @@
     <% if @minimum_password_length %>
     <em>(<%= @minimum_password_length %> characters minimum)</em>
     <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
   </div>
 
   <div class="field">
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
+  <div class="actions mt-2">
+    <%= f.submit "Sign up", class: 'btn btn-success' %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,12 +3,12 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
   </div>
 
   <div class="field">
     <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %>
   </div>
 
   <% if devise_mapping.rememberable? %>
@@ -18,8 +18,8 @@
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+  <div class="actions mt-2">
+    <%= f.submit "Log in", class: 'btn btn-primary' %>
   </div>
 <% end %>
 

--- a/app/views/shared/_filter_form.html.erb
+++ b/app/views/shared/_filter_form.html.erb
@@ -1,21 +1,21 @@
 <%= form_tag(destination_url, method: 'get', id: 'filter-form' ) do %>
   <div class='row'>
-    <div class='col-8'>
+    <div class='col-12 col-md-8 mb-2'>
       <%= text_field_tag :search, params[:search],
                                   placeholder: "Search Entries",
                                   class: 'form-control'
       %>
     </div>
 
-    <div class='col-2'>
+    <div class='col-12 col-md-2 mb-2'>
       <%= select_tag :given_year,
         options_for_select(years_dropdown, params[:given_year]),
         class: 'form-control'
       %>
     </div>
 
-    <div class='col-2'>
-      <button type='submit' class='btn btn-outline-primary'>Submit</button>
+    <div class='col-12 col-md-2'>
+      <button type='submit' class='btn btn-outline-primary' style="width: 100%;">Submit</button>
       <%= link_to 'Reset', destination_url, class: 'ml-3' %>
     </div>
   </div> <!-- row -->


### PR DESCRIPTION



## Related Issues & PRs
Closes #26

## Problems Solved
* fixes signin/up form styling
* allows search form on index to be mobile friendly
* adds "By Year" dropdown to navbar

## Screenshots
By Year
<img width="179" alt="Screenshot 2020-03-07 18 39 44" src="https://user-images.githubusercontent.com/8680712/76154509-35657a00-60a3-11ea-8114-8231eefec305.png">

Mobile-friendly form
<img width="192" alt="Screenshot 2020-03-07 18 40 04" src="https://user-images.githubusercontent.com/8680712/76154510-35fe1080-60a3-11ea-8e77-fb0c4e8ff0fb.png">


## Things Learned
It was fun making a dropdown of years that link to the existing search query. It is nice to have scopes and half of the functionality in place. It made this feature easy peasy to implement. 
