### PR TITLE
16 make filter for past year

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module PostsHelper
-  def years_dropdown
-    Report.available_years.push('All Time')
+  def timeframes_dropdown
+    Report.available_years + Report.timeframe_labels
   end
 
   def display_categories(post)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,7 +1,24 @@
 # frozen_string_literal: true
 
 class Report < ApplicationRecord
+  TIMEFRAMES = {
+    'Past Week' => 7,
+    'Past Month' => 30,
+    'Past Quarter' => 90,
+    'Past Half Year' => 182,
+    'Past Year' => 365,
+    'All Time' => nil
+  }.freeze
+
   class << self
+    def timeframe_labels
+      TIMEFRAMES.keys
+    end
+
+    def this_year
+      Time.zone.today.year
+    end
+
     def available_years(model = Post, date_field = :date)
       model.all.pluck(date_field).map(&:year).uniq.sort.reverse
     end

--- a/app/views/shared/_filter_form.html.erb
+++ b/app/views/shared/_filter_form.html.erb
@@ -9,7 +9,7 @@
 
     <div class='col-12 col-md-2 mb-2'>
       <%= select_tag :given_year,
-        options_for_select(years_dropdown, params[:given_year]),
+        options_for_select(timeframes_dropdown, params[:given_year]),
         class: 'form-control'
       %>
     </div>

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -3,17 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe PostsHelper, type: :helper do
-  let(:last_item) { 'All Time' }
-
-  describe 'years_dropdown' do
+  describe 'timeframes_dropdown' do
     it 'lists all available years' do
-      allow(Report).to receive(:available_years).and_return([2019])
-      expect(helper.years_dropdown).to eq([2019, last_item])
+      allow(Report).to receive(:available_years).and_return([2018, 2019])
+
+      expect(helper.timeframes_dropdown).to include(2018)
+      expect(helper.timeframes_dropdown).to include(2019)
     end
 
-    it 'has "All Time" as the last option' do
+    it 'includes timeline options' do
       allow(Report).to receive(:available_years).and_return([2019])
-      expect(helper.years_dropdown.last).to eq(last_item)
+      allow(Report).to receive(:timeframe_labels).and_return(['Past Week'])
+
+      expect(helper.timeframes_dropdown).to include('Past Week')
+    end
+
+    it 'lists years before timeframe options' do
+      allow(Report).to receive(:available_years).and_return([2019])
+      allow(Report).to receive(:timeframe_labels).and_return(['Past Week'])
+
+      expect(helper.timeframes_dropdown).to eq([2019, 'Past Week'])
     end
   end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -43,8 +43,82 @@ RSpec.describe Post, type: :model do
     end
   end
 
+  describe 'self.for_timeframe' do
+    let!(:post_today) { create(:post, date: Time.zone.today) }
+    let!(:post_past_week) { create(:post, date: (Time.zone.today - 3)) }
+    let!(:post_past_month) { create(:post, date: (Time.zone.today - 15)) }
+    let!(:post_past_quarter) { create(:post, date: (Time.zone.today - 80)) }
+
+    it 'only returns posts for the given timeframe' do
+      posts = Post.for_timeframe('Past Month')
+
+      expect(posts).to include(post_today)
+      expect(posts).to include(post_past_week)
+      expect(posts).to include(post_past_month)
+      expect(posts).to_not include(post_past_quarter)
+    end
+
+    it 'returns all posts when the given_year is "All Time"' do
+      posts = Post.for_timeframe('All Time')
+      expect(posts.count).to eq(4)
+    end
+
+    it 'returns all posts when the given_year is invalid' do
+      posts = Post.for_timeframe('something invalid')
+      expect(posts.count).to eq(4)
+    end
+  end
+
   describe 'self.search' do
-    xit 'does stuff' do
+    it 'returns all posts for current year if no terms are given' do
+      last_year_post = create(:post, date: '2019-01-16')
+      this_year_post = create(:post, date: '2020-01-16')
+
+      allow(Report).to receive(:this_year).and_return('2020')
+      results = Post.search
+
+      expect(results).to_not include(last_year_post)
+      expect(results).to include(this_year_post)
+    end
+
+    it 'if a year is given, it returns posts only from the given year' do
+      last_year_post = create(:post, date: '2019-01-16')
+      this_year_post = create(:post, date: '2020-01-16')
+      given_year = '2019'
+
+      results = Post.search(given_year: given_year)
+
+      expect(results).to include(last_year_post)
+      expect(results).to_not include(this_year_post)
+    end
+
+    it 'returns only post with both the given year and given term if present' do
+      given_year = '2019'
+      search_terms = 'kittens'
+
+      right_year_right_term = create(:post, date: '2019-01-01', description: search_terms)
+      right_year_wrong_term = create(:post, date: '2019-01-02', description: 'puppies')
+      wrong_year_right_term = create(:post, date: '2020-01-16', description: search_terms)
+
+      results = Post.search(given_year: given_year, search_terms: search_terms)
+
+      expect(results).to include(right_year_right_term)
+      expect(results).to_not include(right_year_wrong_term)
+      expect(results).to_not include(wrong_year_right_term)
+    end
+
+    it 'returns all posts when given_year is "All Time"' do
+      given_year = 'All Time'
+
+      post1 = create(:post, date: '2018-01-01')
+      post2 = create(:post, date: '2019-01-01')
+      post3 = create(:post, date: '2020-01-01')
+
+      results = Post.search(given_year: given_year)
+
+      expect(results).to include(post1)
+      expect(results).to include(post2)
+      expect(results).to include(post3)
     end
   end
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #16

## Problems Solved
* I wanted to be able to review my TILs every week, so querying by 'past week' was needed
* I wanted to be able to review my Merits by quarter and other useful job-related review periods, so I added those.
* Now i can filter by type (TIL) and timeframe (past week)

## Things Learned
* Separation of concerns was really throwing me here. I needed to write a bunch of logic about querying, but it didn't seem to belong in the `Post` model. Moving that querying logic into a `Report` model made is seem like `Post` had to know a lot about `Report` to query well. I feel like I separated some things well, but others still feel messy.
