### PR TITLE
Fix ordering of New Years Eve query

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,9 +11,10 @@ class ReportsController < ApplicationController
 
   def new_years_eve
     given_year = Time.zone.now.year
-    @celebrations = current_user.posts.search(given_year: given_year, search_terms: '')
-                                .for_gratitude_and_praise
+    @celebrations = current_user.posts
                                 .in_chronological_order
+                                .search(given_year: given_year, search_terms: '')
+                                .for_gratitude_and_praise
                                 .paginate(page: params[:page], per_page: 1)
   end
 end


### PR DESCRIPTION
## Problems Solved
* The `in_chronological_order` scope was not working. It was displaying in `DESC` instead of `ASC`.
* It was not running correctly because of the order in which the scopes were being chained.
* The solution was to put it _after_ the search scope

