### PR TITLE
Fix image width on mobile

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -10,9 +10,10 @@ body { background-image: image-url('hatch_marks.png'); }
   padding-top: 1rem;
 }
 
-.image {
-  max-width: 600px;
-  // width: 100%;
+.image { max-width: 600px; }
+
+@media screen and (max-width: $mobile-breakpoint) {
+  .image { width: 100%; }
 }
 
 .environment-banner {

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -13,7 +13,7 @@ body { background-image: image-url('hatch_marks.png'); }
 .image { max-width: 600px; }
 
 @media screen and (max-width: $mobile-breakpoint) {
-  .image { width: 100%; }
+  .image { max-width: 100%; }
 }
 
 .environment-banner {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -2,6 +2,7 @@
 $card-image-height: 100px;
 $card-height: $card-image-height * 4;
 $table-thumbnail: 40px;
+$mobile-breakpoint: 600px;
 
 // Colors: Brand Assignments
 $brand-dark-blue: #2b5f6e;


### PR DESCRIPTION
## Problems Solved
On mobile, images exceed the boundaries of the card.

<img width="397" alt="Screen Shot 2023-01-17 at 5 27 26 PM" src="https://user-images.githubusercontent.com/8680712/213035006-ad667699-d00b-4ddf-907c-f3c5e0c4ef9b.png">


This PR adds a max-width of 100% to mobile only. This achieves:
* images still do not exceed 600px on desktop
* images do not exceed the frame on mobile
* smaller images (50px, 100px, etc) are not stretched to fix the 100% on mobile or desktop.

<img width="397" alt="Screen Shot 2023-01-17 at 5 27 26 PM" src="https://user-images.githubusercontent.com/8680712/213034944-e14bcd42-83ad-482f-820c-25a1ab5765d8.png">
