### PR TITLE
Unfreeze bundler for Dependabot only

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -29,13 +29,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       # Add or replace dependency steps here
+      - name: Unfreeze Bundler for Dependabot
+        if: github.actor == 'dependabot[bot]'
+        run: bundle config set frozen false
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
       # Add or replace database setup steps here
       - name: Set up database schema
         run: bin/rails db:schema:load
+
       # Add or replace test runners here
       - name: Run tests
         run: bundle exec rspec
@@ -58,10 +63,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       # Add or replace dependency steps here
+      - name: Unfreeze Bundler for Dependabot
+        if: github.actor == 'dependabot[bot]'
+        run: bundle config set frozen false
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
       # Add or replace database setup steps here
       - name: Set up database schema
         run: bin/rails db:schema:load
@@ -72,17 +81,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+      # Add or replace dependency steps here
+      - name: Unfreeze Bundler for Dependabot
+        if: github.actor == 'dependabot[bot]'
+        run: bundle config set frozen false
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      # Add or replace any other lints here
-      - name: StandardRB
+          cache-version: 1 # Increment this to clear cache if needed
+      - name: Standard RB
         run: bundle exec standardrb
-      # - name: Reek
-      #   run: bundle exec reek
-      # - name: Security audit dependencies
-      #   run: bin/bundler-audit --update
-      # - name: Security audit application code
-      #   run: bin/brakeman -q -w2
+  #     #Add or replace any other lints here
+  #     - name: Reek
+  #       run: bundle exec reek
+  #     - name: Security audit dependencies
+  #       run: bin/bundler-audit --update
+  #     - name: Security audit application code
+  #       run: bin/brakeman -q -w2


### PR DESCRIPTION
## This PR...
Conditionally unfreezes bundler in CI only when Dependabot is the author. This preserves frozen mode for regular PRs (catching real dependency mismatches) while allowing Dependabot's updates to proceed.

## Why
### Before Bundler 4 (Bundler 2–3)
In bundler 2–3, the frozen mode was opt-in via bundle install --frozen. In CI environments, it wasn't the default behavior. Dependabot could:
* Update Gemfile (e.g., bump standard gem)
* Run bundle install (which would regenerate Gemfile.lock)
* Commit both files
* CI would run with the new lockfile

No frozen mode conflicts because bundler would happily resolve and update the lockfile.

### After Bundler 4 (Current Behavior)
Bundler 4 now defaults to frozen mode in CI-like environments. The key insight from your bundler 4.0.3 footer in the Gemfile.lock:
* Bundler 4 auto-detects CI environments (via CI=true env var or similar)
* When detected, it automatically enables frozen mode without explicit flags
* Frozen mode prevents Gemfile.lock modification, even if Gemfile changed

This breaks Dependabot's workflow:
* Dependabot updates Gemfile (e.g., standard 1.54.0 → 1.55.0)
* Dependabot also updates Gemfile.lock
* But when the CI workflow runs, bundler 4 sees both files and enforces a match
* If they don't match perfectly (due to transitive dependency differences), frozen mode rejects it

### Why This Matters for Dependabot
Dependabot updates lockfiles, but it may not account for every transitive dependency change that bundler 4 would compute. Bundler 4's stricter frozen mode catches this discrepancy and fails rather than updating.
