### PR TITLE
Update README for Heroku buildpack approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,25 +84,24 @@ Images are processed by the Rails gem `image_processing` which uses the `ruby-vi
 ## Deploying
 
 ### Heroku Setup for libvips
-The app requires libvips for image processing. Configure buildpacks via the Heroku Dashboard:
+The app requires libvips for image processing. This is handled via an `Aptfile` in the repo root that lists the required system packages.
 
-1. Go to https://dashboard.heroku.com/apps/myfoodplanner/settings
+**Configure buildpacks** via the Heroku Dashboard:
+
+1. Go to your app settings at https://dashboard.heroku.com/apps/YOUR_APP_NAME/settings
 2. Scroll to "Buildpacks" section
 3. Ensure buildpacks are in this order:
-   - `https://github.com/Newlywords/heroku-buildpack-vips`
+   - `https://github.com/heroku/heroku-buildpack-apt`
    - `heroku/ruby`
 
-**Alternative via CLI** (if Heroku CLI is working):
+**Alternative via CLI:**
 ```bash
-heroku buildpacks:add --index 1 hthttps://github.com/Newlywords/heroku-buildpack-vips -a myfoodplanner
-heroku buildpacks:add --index 2 heroku/ruby -a myfoodplanner
+heroku buildpacks:clear -a YOUR_APP_NAME
+heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-apt -a YOUR_APP_NAME
+heroku buildpacks:add --index 2 heroku/ruby -a YOUR_APP_NAME
 ```
 
-**Note:** If you encounter Heroku CLI errors, use the dashboard method above or reinstall the CLI with:
-```bash
-brew uninstall heroku
-brew install heroku/brew/heroku
-```
+The `heroku-buildpack-apt` will read the `Aptfile` and install libvips before the Ruby buildpack runs.
 
 
 ## Related Docs


### PR DESCRIPTION
## Summary
Updates README deployment instructions to use the officially maintained `heroku-buildpack-apt` instead of the unmaintained `heroku-buildpack-vips`.

## Changes
- ✅ Updated Heroku deployment section with new buildpack instructions
- ✅ Clearer explanation of how libvips is installed via Aptfile
- ✅ Simplified CLI commands
- ✅ Works with modern Heroku stacks (heroku-26)

## Why this change?
- The `Newlywords/heroku-buildpack-vips` buildpack is unmaintained and doesn't work with heroku-26
- `heroku-buildpack-apt` is officially maintained by Heroku
- More reliable and compatible with current infrastructure

## Related
- Part of the ruby-vips migration (PR #160)
- Aptfile committed in PR #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)